### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This sources are prepared for IntelliJ IDEA and Android Studio. Unfortunately In
 
 More information
 ----------------
-####Telegram project
+#### Telegram project
 
 http://telegram.org/
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
